### PR TITLE
Improve configuration handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration for Hauban IA Watch
+TOGETHER_API_KEY=your-together-api-key
+TOGETHER_MODEL=mistralai/Mixtral-8x7B-Instruct-v0.1
+MAILJET_API_KEY=your-mailjet-api-key
+MAILJET_SECRET_KEY=your-mailjet-secret-key
+EMAIL_FROM=bot@example.com
+GOOGLE_SHEET_URL=https://docs.google.com/spreadsheets/d/your-sheet-id
+SERVICE_ACCOUNT_FILE=google-credentials.json

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ You will then receive your first report the next morning!
 - Email System: Mailjet SMTP
 - News Sources: TechCrunch, VentureBeat, Reddit, GitHub, Hugging Face, ArXiv
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and fill in your API keys and configuration values:
+
+```
+cp .env.example .env
+```
+
+The script reads the following variables:
+
+- `TOGETHER_API_KEY`
+- `TOGETHER_MODEL`
+- `MAILJET_API_KEY`
+- `MAILJET_SECRET_KEY`
+- `EMAIL_FROM`
+- `GOOGLE_SHEET_URL`
+- `SERVICE_ACCOUNT_FILE`
+
 ---
 
 ## ⚠️ Terms of Service


### PR DESCRIPTION
## Summary
- move credentials into environment variables
- add docstrings and an example `.env` file
- document the new configuration in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f530b834083209e721ff633722f9a